### PR TITLE
on destroy, remove the data related to the plugin

### DIFF
--- a/elastic/src/main/java/com/arcbees/gquery/elastic/client/Elastic.java
+++ b/elastic/src/main/java/com/arcbees/gquery/elastic/client/Elastic.java
@@ -47,7 +47,7 @@ public class Elastic extends GQuery {
     public Elastic elastic(ElasticOption options) {
         for (Element e : elements()) {
             GQuery $e = $(e);
-            if (isSupported() && $e.data(ELASTIC_DATA_KEY) == null) {
+            if (isSupported() && getImpl(e) == null) {
                 ElasticImpl impl = new ElasticImpl(e, options);
                 $e.data(ELASTIC_DATA_KEY, impl);
             }
@@ -60,6 +60,7 @@ public class Elastic extends GQuery {
             ElasticImpl impl = getImpl(e);
             if (impl != null) {
                 impl.destroy();
+                $(e).removeData(ELASTIC_DATA_KEY);
             }
         }
         return this;

--- a/elastic/src/main/java/com/arcbees/gquery/elastic/client/ElasticImpl.java
+++ b/elastic/src/main/java/com/arcbees/gquery/elastic/client/ElasticImpl.java
@@ -99,7 +99,7 @@ public class ElasticImpl {
 
     private Element container;
     private LayoutCommand layoutCommand;
-    // Deque interface not supported by gwt
+    // Deque interfaces not supported by gwt
     private PriorityQueue<Integer> columnPriorities;
     private List<Double> columnHeights;
     private boolean useTranslate3d;


### PR DESCRIPTION
The destroy method didn't clean the plugin stuff enough. With this bug when a ElasticHtmlPanel is added to the dom, then removed and then added again, the plugin didn't work anymore
